### PR TITLE
avoid aggressive socket connection error callback

### DIFF
--- a/src/main/java/com/hsbc/cranker/connector/ConnectorSocket.java
+++ b/src/main/java/com/hsbc/cranker/connector/ConnectorSocket.java
@@ -60,6 +60,7 @@ public interface ConnectorSocket {
         }
 
         /**
+         * completion state
          * @return true if it's in end state
          */
         public boolean isCompleted() {
@@ -68,11 +69,13 @@ public interface ConnectorSocket {
     }
 
     /**
+     * connection state
      * @return The current state of this connection
      */
     State state();
 
     /**
+     * cranker connection protocol version
      * @return The connector socket's version, e.g. "cranker_3.0", "cranker_1.0"
      */
     String version();

--- a/src/main/java/com/hsbc/cranker/connector/CrankerConnector.java
+++ b/src/main/java/com/hsbc/cranker/connector/CrankerConnector.java
@@ -41,12 +41,14 @@ public interface CrankerConnector {
     boolean stop(long timeout, TimeUnit timeUnit);
 
     /**
+     * connectorId
      * @return A unique ID assigned to this connector that is provided to the router for diagnostic reasons.
      */
     String connectorId();
 
     /**
-     * @return Meta data about the routers that this connector is connected to. Provided for diagnostic purposes.
+     * list of the router registration
+     * @return Metadata about the routers that this connector is connected to. Provided for diagnostic purposes.
      */
     List<RouterRegistration> routers();
 }

--- a/src/main/java/com/hsbc/cranker/connector/CrankerConnectorBuilder.java
+++ b/src/main/java/com/hsbc/cranker/connector/CrankerConnectorBuilder.java
@@ -16,6 +16,11 @@ import static com.hsbc.cranker.connector.HttpUtils.createHttpClientBuilder;
 public class CrankerConnectorBuilder {
 
     /**
+     * prevent constructing CrankerConnectorBuilder, should use <code>CrankerConnectorBuilder.connector()</code> instead.
+     */
+    private CrankerConnectorBuilder() {}
+
+    /**
      * cranker protocol 1.0
      */
     public final static String CRANKER_PROTOCOL_1 = "cranker_1.0";
@@ -241,6 +246,7 @@ public class CrankerConnectorBuilder {
     }
 
     /**
+     * constructing a new connector builder
      * @return A new connector builder
      */
     public static CrankerConnectorBuilder connector() {

--- a/src/main/java/com/hsbc/cranker/connector/RegistrationUriSuppliers.java
+++ b/src/main/java/com/hsbc/cranker/connector/RegistrationUriSuppliers.java
@@ -20,6 +20,11 @@ import static java.util.Objects.requireNonNull;
 public class RegistrationUriSuppliers {
 
     /**
+     * preventing constructing RegistrationUriSuppliers, as it's a util class.
+     */
+    private RegistrationUriSuppliers() {}
+
+    /**
      * Creates a supplier that always returns a fixed set of URIs
      * @param uris The URIs to return, in the format <code>wss://crankerrouter.example.org</code>
      * @return A registration URI supplier

--- a/src/main/java/com/hsbc/cranker/connector/RouterEventListener.java
+++ b/src/main/java/com/hsbc/cranker/connector/RouterEventListener.java
@@ -38,6 +38,7 @@ public interface RouterEventListener {
         private final List<RouterRegistration> unchanged;
 
         /**
+         * The routers that have been newly registered
          * @return The routers that have been newly registered
          */
         public List<RouterRegistration> added() {
@@ -45,6 +46,7 @@ public interface RouterEventListener {
         }
 
         /**
+         * The routers that are no longer being connected to
          * @return The routers that are no longer being connected to
          */
         public List<RouterRegistration> removed() {
@@ -52,6 +54,7 @@ public interface RouterEventListener {
         }
 
         /**
+         * The routers that remain unchanged
          * @return The routers that remain unchanged
          */
         public List<RouterRegistration> unchanged() {


### PR DESCRIPTION
Avoid aggressive socket connection error callback and some javadoc fix. 

```java
    public void onClose(ConnectorSocket socket, Throwable error) {
        runningSockets.remove(socket);
        idleSockets.remove(socket);
        if (error == null) {
            addAnyMissing();
        } else {
            // if error, adding back sockets with backoff
            addAnythingMissingWithBackoff(); 
        }
    }
```

The majority change is here. this onClose() method will be invoked for normal close and error close. we want to make sure it done the backoff when error happened (at least do the reconnect with backoff start from 502 ms till 10 second) .