### PR TITLE
fix HttpUtils.createHttpClientBuilder(trustAll)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 21 ]
     name: Java ${{ matrix.java }} build
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -81,14 +81,12 @@ use HTTPS/WSS or plain HTTP/WS. If using a secure connection, then the default J
 self-signed certs are used (which is common for localhost communications), you can specify a client that trusts
 all SSL certs on the `CrankerConnectorBuilder`.
 
-Note that if you need to disable hostname verification (e.g. when connecting to routers via IP addresses) then this needs
-to be set as a system property before any HttpClient code is used by setting a system property.
+Note that if you need to disable hostname verification (e.g., when connecting to routers via IP addresses), we provide a handy helper `CrankerConnectorBuilder.createHttpClient(true).build()` to create a JDK HTTP client instance that trusts all certificates and disables hostname verification.
 
 The following shows a full example:
 
 ````java
 public static void main(String[] args) {
-    System.setProperty("jdk.internal.httpclient.disableHostnameVerification", "true");
 
     URI targetServiceUri = startedWebServerUri();
     

--- a/pom.xml
+++ b/pom.xml
@@ -54,43 +54,43 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.hsbc.cranker</groupId>
             <artifactId>mu-cranker-router</artifactId>
-            <version>1.0.3</version>
+            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.muserver</groupId>
             <artifactId>mu-server</artifactId>
-            <version>0.74.2</version>
+            <version>2.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.0</version>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.11.0</version>
+            <version>4.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
-            <version>4.11.0</version>
+            <version>4.12.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/hsbc/cranker/connector/HttpUtils.java
+++ b/src/main/java/com/hsbc/cranker/connector/HttpUtils.java
@@ -1,8 +1,7 @@
 package com.hsbc.cranker.connector;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.*;
+import java.net.Socket;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -63,19 +62,45 @@ class HttpUtils {
     private static void trustAll(HttpClient.Builder builder) {
         try {
             final TrustManager[] trustAllCerts = new TrustManager[]{
-                new X509TrustManager() {
-                    @Override
-                    public void checkClientTrusted(X509Certificate[] chain, String authType) {
-                    }
-                    @Override
-                    public void checkServerTrusted(X509Certificate[] chain, String authType) {
-                    }
-                    @Override
+                new X509ExtendedTrustManager() {
                     public X509Certificate[] getAcceptedIssuers() {
-                        return new X509Certificate[0];
+                        return null;
                     }
-                }
-            };
+
+                    public void checkClientTrusted(
+                        final X509Certificate[] a_certificates,
+                        final String a_auth_type) {
+                    }
+
+                    public void checkServerTrusted(
+                        final X509Certificate[] a_certificates,
+                        final String a_auth_type) {
+                    }
+
+                    public void checkClientTrusted(
+                        final X509Certificate[] a_certificates,
+                        final String a_auth_type,
+                        final Socket a_socket) {
+                    }
+
+                    public void checkServerTrusted(
+                        final X509Certificate[] a_certificates,
+                        final String a_auth_type,
+                        final Socket a_socket) {
+                    }
+
+                    public void checkClientTrusted(
+                        final X509Certificate[] a_certificates,
+                        final String a_auth_type,
+                        final SSLEngine a_engine) {
+                    }
+
+                    public void checkServerTrusted(
+                        final X509Certificate[] a_certificates,
+                        final String a_auth_type,
+                        final SSLEngine a_engine) {
+                    }
+                }};
             SSLContext sslContext = SSLContext.getInstance("SSL");
             sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
             builder.sslContext(sslContext);

--- a/src/test/java/com/hsbc/cranker/connector/HttpUtilsTest.java
+++ b/src/test/java/com/hsbc/cranker/connector/HttpUtilsTest.java
@@ -30,7 +30,9 @@ class HttpUtilsTest {
             .start();
 
 
-        assertThrows(SSLHandshakeException.class, () -> {
+        // on JDK 11, it's IOException
+        // on JDK 17, it's SSLHandshakeException
+        assertThrows(Exception.class, () -> {
             HttpClient client = HttpUtils.createHttpClientBuilder(false).build();
             client.send(HttpRequest.newBuilder(server.uri()).build(), HttpResponse.BodyHandlers.ofString());
         });

--- a/src/test/java/com/hsbc/cranker/connector/HttpUtilsTest.java
+++ b/src/test/java/com/hsbc/cranker/connector/HttpUtilsTest.java
@@ -1,0 +1,56 @@
+package com.hsbc.cranker.connector;
+
+import io.muserver.HttpsConfigBuilder;
+import io.muserver.MuServer;
+import io.muserver.MuServerBuilder;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLHandshakeException;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HttpUtilsTest {
+
+    @Test
+    void nonTrustAllClientThrowsExceptionWhenConnectToSelfSignedCertServer() throws IOException, InterruptedException {
+
+        MuServer server = MuServerBuilder.httpsServer()
+            .withHttpsConfig(HttpsConfigBuilder.unsignedLocalhost())
+            .addHandler((request, response) -> {
+                response.status(200);
+                response.write("Hello");
+                return true;
+            })
+            .start();
+
+
+        assertThrows(SSLHandshakeException.class, () -> {
+            HttpClient client = HttpUtils.createHttpClientBuilder(false).build();
+            client.send(HttpRequest.newBuilder(server.uri()).build(), HttpResponse.BodyHandlers.ofString());
+        });
+    }
+
+    @Test
+    void testTrustAllClient() throws IOException, InterruptedException {
+
+        MuServer server = MuServerBuilder.httpsServer()
+            .withHttpsConfig(HttpsConfigBuilder.unsignedLocalhost())
+            .addHandler((request, response) -> {
+                response.status(200);
+                response.write("Hello");
+                return true;
+            })
+            .start();
+
+        HttpClient client = HttpUtils.createHttpClientBuilder(true).build();
+        HttpResponse<String> response = client.send(HttpRequest.newBuilder(server.uri()).build(), HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode(), equalTo(200));
+        assertThat(response.body(), equalTo("Hello"));
+    }
+}

--- a/src/test/java/com/hsbc/cranker/connector/HttpUtilsTest.java
+++ b/src/test/java/com/hsbc/cranker/connector/HttpUtilsTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class HttpUtilsTest {
 
     @Test
-    void nonTrustAllClientThrowsExceptionWhenConnectToSelfSignedCertServer() throws IOException, InterruptedException {
+    void nonTrustAllClientThrowsExceptionWhenConnectToSelfSignedCertServer() {
 
         MuServer server = MuServerBuilder.httpsServer()
             .withHttpsConfig(HttpsConfigBuilder.unsignedLocalhost())


### PR DESCRIPTION
Fix HttpUtils.createHttpClientBuilder(trustAll) for creating a http client instance that trust all certificate, so that we don't need to disable the host verification globally.