### PR TITLE
Process server sent close messages in the deregistration socket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hsbc.cranker</groupId>
     <artifactId>cranker-connector</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.3-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>A Cranker connector for Java as a library that has no external dependencies</description>
     <url>https://github.com/hsbc/cranker-connector</url>

--- a/src/main/java/com/hsbc/cranker/connector/CrankerConnector.java
+++ b/src/main/java/com/hsbc/cranker/connector/CrankerConnector.java
@@ -54,6 +54,7 @@ public interface CrankerConnector {
     List<RouterRegistration> routers();
 
     /**
+     * Gets the connector's HTTP client
      * @return the HTTP client used for the connections to the router and target server
      */
     HttpClient httpClient();

--- a/src/main/java/com/hsbc/cranker/connector/CrankerConnector.java
+++ b/src/main/java/com/hsbc/cranker/connector/CrankerConnector.java
@@ -1,6 +1,7 @@
 package com.hsbc.cranker.connector;
 
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -51,6 +52,11 @@ public interface CrankerConnector {
      * @return Metadata about the routers that this connector is connected to. Provided for diagnostic purposes.
      */
     List<RouterRegistration> routers();
+
+    /**
+     * @return the HTTP client used for the connections to the router and target server
+     */
+    HttpClient httpClient();
 }
 
 class CrankerConnectorImpl implements CrankerConnector {
@@ -66,12 +72,13 @@ class CrankerConnectorImpl implements CrankerConnector {
     private final TimeUnit routerUpdateTimeUnit;
     private final int routerDeregisterTimeout;
     private final TimeUnit routerDeregisterTimeUnit;
+    private final HttpClient httpClient;
 
     CrankerConnectorImpl(String connectorId, RouterRegistrationImpl.Factory routerConFactory,
                          Supplier<Collection<URI>> crankerUriSupplier, String componentName,
                          RouterEventListener routerEventListener,
                          int routerUpdateInterval, TimeUnit routerUpdateTimeUnit,
-                         int routerDeregisterTimeout, TimeUnit routerDeregisterTimeUnit) {
+                         int routerDeregisterTimeout, TimeUnit routerDeregisterTimeUnit, HttpClient httpClient) {
         this.componentName = componentName;
         this.connectorId = connectorId;
         this.routerConFactory = routerConFactory;
@@ -81,6 +88,7 @@ class CrankerConnectorImpl implements CrankerConnector {
         this.routerUpdateTimeUnit = routerUpdateTimeUnit;
         this.routerDeregisterTimeout = routerDeregisterTimeout;
         this.routerDeregisterTimeUnit = routerDeregisterTimeUnit;
+        this.httpClient = httpClient;
     }
 
     CompletableFuture<Void> updateRoutersAsync() {
@@ -209,5 +217,10 @@ class CrankerConnectorImpl implements CrankerConnector {
     @Override
     public String toString() {
         return "CrankerConnector (" + connectorId + ") registered to: " + routers;
+    }
+
+    @Override
+    public HttpClient httpClient() {
+        return httpClient;
     }
 }

--- a/src/main/java/com/hsbc/cranker/connector/CrankerConnectorBuilder.java
+++ b/src/main/java/com/hsbc/cranker/connector/CrankerConnectorBuilder.java
@@ -283,7 +283,7 @@ public class CrankerConnectorBuilder {
         RegistrationEventListener registrationEventListenerToUse = registrationEventListener != null ? registrationEventListener : new RegistrationEventListener(){};
         var factory = new RouterRegistrationImpl.Factory(preferredProtocols, clientToUse, domain, route, slidingWindowSize, target, routerEventListener, proxyEventListenerToUse, registrationEventListenerToUse);
         return new CrankerConnectorImpl(connectorId, factory, crankerUris, componentName, routerEventListener,
-            this.routerUpdateInterval, this.routerUpdateTimeUnit, this.routerDeregisterTimeout, this.routerDeregisterTimeUnit);
+            this.routerUpdateInterval, this.routerUpdateTimeUnit, this.routerDeregisterTimeout, this.routerDeregisterTimeUnit, clientToUse);
     }
 
     /**

--- a/src/main/java/com/hsbc/cranker/connector/RouterRegistration.java
+++ b/src/main/java/com/hsbc/cranker/connector/RouterRegistration.java
@@ -140,6 +140,7 @@ class RouterRegistrationImpl implements ConnectorSocketListener, RouterRegistrat
                 @Override
                 public void onOpen(WebSocket webSocket) {
                     webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "");
+                    webSocket.request(1); // so that we can receive the server's close message and shut down gracefully
                 }
             })
             .thenCompose(webSocket -> {


### PR DESCRIPTION
Without this, deregistration web sockets aren’t closed which makes cleaning up the http client hang until the socket times out