### PR TITLE
Handle NumberFormatException in Content-Length parsing

### DIFF
--- a/src/main/java/com/hsbc/cranker/connector/ConnectorSocketV3.java
+++ b/src/main/java/com/hsbc/cranker/connector/ConnectorSocketV3.java
@@ -1,5 +1,7 @@
 package com.hsbc.cranker.connector;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -18,6 +20,7 @@ import java.util.function.Function;
  * A single connection between a connector and a router in protocol cranker_v3 implementation
  */
 public class ConnectorSocketV3 implements WebSocket.Listener, ConnectorSocket {
+    private static final Logger LOG = LoggerFactory.getLogger(ConnectorSocketV3.class);
 
     static final byte MESSAGE_TYPE_DATA = 0;
     static final byte MESSAGE_TYPE_HEADER = 1;
@@ -698,7 +701,12 @@ public class ConnectorSocketV3 implements WebSocket.Listener, ConnectorSocket {
                 if (headerLine.toLowerCase().startsWith("content-length:")) {
                     String[] split = headerLine.split(":");
                     if (split.length == 2) {
-                        return Long.parseLong(split[1].trim());
+                        try {
+                            return Long.parseLong(split[1].trim());
+                        } catch (NumberFormatException e) {
+                            LOG.warn("Invalid Content-Length header value: " + split[1].trim());
+                            return -1;
+                        }
                     }
                 }
             }

--- a/src/main/java/com/hsbc/cranker/connector/ConnectorSocketV3.java
+++ b/src/main/java/com/hsbc/cranker/connector/ConnectorSocketV3.java
@@ -1,7 +1,5 @@
 package com.hsbc.cranker.connector;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -20,7 +18,6 @@ import java.util.function.Function;
  * A single connection between a connector and a router in protocol cranker_v3 implementation
  */
 public class ConnectorSocketV3 implements WebSocket.Listener, ConnectorSocket {
-    private static final Logger LOG = LoggerFactory.getLogger(ConnectorSocketV3.class);
 
     static final byte MESSAGE_TYPE_DATA = 0;
     static final byte MESSAGE_TYPE_HEADER = 1;
@@ -704,7 +701,6 @@ public class ConnectorSocketV3 implements WebSocket.Listener, ConnectorSocket {
                         try {
                             return Long.parseLong(split[1].trim());
                         } catch (NumberFormatException e) {
-                            LOG.warn("Invalid Content-Length header value: " + split[1].trim());
                             return -1;
                         }
                     }

--- a/src/main/java/com/hsbc/cranker/connector/CrankerRequestParser.java
+++ b/src/main/java/com/hsbc/cranker/connector/CrankerRequestParser.java
@@ -1,11 +1,14 @@
 package com.hsbc.cranker.connector;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 
 /**
  * Request from router to connector
  */
 class CrankerRequestParser {
+    private static final Logger LOG = LoggerFactory.getLogger(CrankerRequestParser.class);
     public static final String REQUEST_BODY_PENDING_MARKER = "_1";
     public static final String REQUEST_HAS_NO_BODY_MARKER = "_2";
     public static final String REQUEST_BODY_ENDED_MARKER = "_3";
@@ -58,7 +61,12 @@ class CrankerRequestParser {
             if (headerLine.toLowerCase().startsWith("content-length:")) {
                 String[] split = headerLine.split(":");
                 if (split.length == 2) {
-                    return Long.parseLong(split[1].trim());
+                    try {
+                        return Long.parseLong(split[1].trim());
+                    } catch (NumberFormatException e) {
+                        LOG.warn("Invalid Content-Length header value: " + split[1].trim());
+                        return -1;
+                    }
                 }
             }
         }

--- a/src/main/java/com/hsbc/cranker/connector/CrankerRequestParser.java
+++ b/src/main/java/com/hsbc/cranker/connector/CrankerRequestParser.java
@@ -1,14 +1,11 @@
 package com.hsbc.cranker.connector;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 
 /**
  * Request from router to connector
  */
 class CrankerRequestParser {
-    private static final Logger LOG = LoggerFactory.getLogger(CrankerRequestParser.class);
     public static final String REQUEST_BODY_PENDING_MARKER = "_1";
     public static final String REQUEST_HAS_NO_BODY_MARKER = "_2";
     public static final String REQUEST_BODY_ENDED_MARKER = "_3";
@@ -64,7 +61,6 @@ class CrankerRequestParser {
                     try {
                         return Long.parseLong(split[1].trim());
                     } catch (NumberFormatException e) {
-                        LOG.warn("Invalid Content-Length header value: " + split[1].trim());
                         return -1;
                     }
                 }


### PR DESCRIPTION

Wraps `Long.parseLong()` calls in try-catch blocks to gracefully handle malformed Content-Length header values. Invalid values now return `-1` (unknown length), consistent with how missing Content-Length headers are already handled.

## Changes

- `CrankerRequestParser.java` - cranker_1.0 protocol
- `ConnectorSocketV3.java` - cranker_3.0 protocol

```java
// Before
return Long.parseLong(split[1].trim());

// After
try {
    return Long.parseLong(split[1].trim());
} catch (NumberFormatException e) {
    return -1;
}
```

## Behavior

| Input | Before | After |
|-------|--------|-------|
| `Content-Length: 100` | `100` | `100` |
| `Content-Length: abc` | `NumberFormatException` | `-1` |
| `Content-Length: 12.5` | `NumberFormatException` | `-1` |
| Missing header | `-1` | `-1` |

## Rationale

- **Consistency**: Malformed values behave like missing headers
- **Defensive programming**: Avoids uncaught exception propagation
- **Minimal change**: No impact on happy path, no new dependencies

## Changes from Previous PR (#16)

The original PR added slf4j logging which violated the zero-runtime-dependency principle. This version:

- Removes slf4j imports entirely
- Uses silent exception handling (no logging)
- Maintains zero external dependencies

## Testing

- All existing tests pass (96 tests)
- Compilation verified with `mvn clean compile`

---

Fixes #15